### PR TITLE
Zugriff auf den Service über IP deaktivieren

### DIFF
--- a/project-template/templates/service.yaml
+++ b/project-template/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "project-template.labels" . | nindent 4 }}
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - name: http
       port: 80


### PR DESCRIPTION
Momentan kann man die Anwendungen über die Domain und über die IP-Adresse erreichen.

Ändert man den Typen der Services nun von `LoadBalancer` auf `ClusterIP`, so "deaktiviert" man den Zugriff mit der IP-Adresse.
Beispiel:

1. Man besucht den Service unter https://test-clusterip-test-clusterip.delta.k8s-wdy.de
> Ergebnis: Man erreicht die Anwendung

2. Man versucht den Service mit der IP-Adresse http://195.192.131.247 zu besuchen
> Ergebnis: Man bekommt ein `default backend - 404`. Der Zugriff wurde sozusagen verweigert