### PR TITLE
probe refactoring

### DIFF
--- a/project-template/templates/deployment.yaml
+++ b/project-template/templates/deployment.yaml
@@ -48,13 +48,13 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.probe.path }}
-              port: {{ .Values.probe.port }}
+              port: {{ .Values.containerPort }}
             failureThreshold: 1
             periodSeconds: 10
           startupProbe:
             httpGet:
               path: {{ .Values.probe.path }}
-              port: {{ .Values.probe.port }}
+              port: {{ .Values.containerPort }}
             failureThreshold: 30
             periodSeconds: 10
           {{ end }}

--- a/project-template/values.yaml
+++ b/project-template/values.yaml
@@ -84,12 +84,13 @@ autoscaling:
 
 # Define an endpoint (and port) through which a health check is provided.
 # This is used by Kubernetes to check when the service is available.
+# The port for the probe will be set automatically. It will be the same,
+# as the value of "containerPort".
 # More Information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 # (OPTIONAL - default: no liveness/startup probe)
 
 # probe:
 #   path: /
-#   port: 8080
 
 
 ################################################################################################


### PR DESCRIPTION
Anhand des Termins vom letzten Donnerstag (09.07.2020), hatte ich mir den Punkt notiert, ob man den Port für die `probe` nicht mit über den `containerPort` setzen könnte.
Dies ist nun auch der Fall. Sollte der Nutzer die Felder für `probe` in der values.yaml setzten, so wird der Wert von `containerPort` automatisch mit übernommen. Der Nutzer muss also nur noch den Pfad angeben, über dem die Probe ausgeführt werden soll.