### PR TITLE
values.namespace und values.name verdreht

### DIFF
--- a/project-template/templates/_helpers.tpl
+++ b/project-template/templates/_helpers.tpl
@@ -33,7 +33,7 @@ example-1-helm-example-1.delta.k8s-wdy.de
 */}}
 {{- define "project-template.domain" -}}
 {{- $clusterdomain := "delta.k8s-wdy.de" -}}
-{{- printf "%s-%s.%s" .Values.name .Values.namespace $clusterdomain -}}
+{{- printf "%s-%s.%s" .Values.namespace .Values.name $clusterdomain -}}
 {{- end -}}
 
 {{/*

--- a/project-template/templates/_helpers.tpl
+++ b/project-template/templates/_helpers.tpl
@@ -27,8 +27,8 @@ Replaces the / in the namespace to an -.
 Project Domain
 
 Every application has its own unique domain {NAMESPACE}-{NAME}.{CLUSTER-DOMAIN}, e.g.:
-example-1-helm-example-1.delta.k8s-wdy.de
-^ NAME    ^ NAMESPACE    ^ CLUSTER-DOMAIN
+helm-example-1-example-1.delta.k8s-wdy.de
+^ NAMESPACE    ^ NAME    ^ CLUSTER-DOMAIN
 
 */}}
 {{- define "project-template.domain" -}}

--- a/project-template/templates/_helpers.tpl
+++ b/project-template/templates/_helpers.tpl
@@ -33,7 +33,7 @@ example-1-helm-example-1.delta.k8s-wdy.de
 */}}
 {{- define "project-template.domain" -}}
 {{- $clusterdomain := "delta.k8s-wdy.de" -}}
-{{- printf "%s-%s.%s" .Values.namespace .Values.name $clusterdomain -}}
+{{- printf "%s-%s.%s" .Values.name .Values.namespace $clusterdomain -}}
 {{- end -}}
 
 {{/*

--- a/project-template/templates/deployment.yaml
+++ b/project-template/templates/deployment.yaml
@@ -62,7 +62,8 @@ spec:
           # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
           # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
           #
-          #pullPolicy: IfNotPresent
+          # We want to always pull the image, because we might use dev/stage/prod as image tags, not only 'latest'
+          imagePullPolicy: Always
           volumeMounts:
             {{- if .Values.persistentVolumes -}}
             {{ range .Values.persistentVolumes }}


### PR DESCRIPTION
Bei der Fehlersuche ist mir eine Sache in der `project-template.domain` Methode aufgefallen. Die Werte waren verdreht, sprich zu erst kam `.Values.namespace´ und dann erst `.Values.name`.
Im Kommentar, der über der Methode steht, sind die Werte andersherum. Ich habe es deshalb erstmal in diesem Branch angepasst. Wollen wir die Variante nehmen, die auf master momentan in der Methode steht, oder so wie es im Kommentar beschrieben wird?