### PR TITLE
replace method

### DIFF
--- a/project-template/templates/_helpers.tpl
+++ b/project-template/templates/_helpers.tpl
@@ -6,7 +6,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "project-template.fullname" -}}
-{{- printf "%s-%s" .Values.name .Values.namespace -}}
+{{- printf "%s-%s" .Values.name .Values.namespace | replace "ä" "ae" |replace "ö" "oe" | replace "ü" "ue"-}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Beim deployment mit Timo ist aufgefallen, das man keine Umlaute nutzen darf. Dies habe ich nun gefixt, indem ich für ä, ö und ü ein replace zu ae, oe und ue eingebaut habe.