### PR TITLE
Add NetworkPolicy for Namespace

### DIFF
--- a/project-template/templates/deployment.yaml
+++ b/project-template/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
       annotations:
         {{- include "project-template.annotations" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "project-template.namespace" . }}-user
-      automountServiceAccountToken: false
+      #serviceAccountName: {{ include "project-template.namespace" . }}-user
+      #automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsGroup: 1000

--- a/project-template/templates/networkpolicy.yaml
+++ b/project-template/templates/networkpolicy.yaml
@@ -6,7 +6,10 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "project-template.selectorLabels" . | nindent 6 }}
+  {{- include "project-template.selectorLabels" . | nindent 6 }}
   ingress:
+    # Allows incoming traffic from the ingress
+    - {}
+    # Deny the traffic from other namespaces
     - from:
         - podSelector: {}

--- a/project-template/templates/networkpolicy.yaml
+++ b/project-template/templates/networkpolicy.yaml
@@ -1,0 +1,12 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: {{ include "project-template.namespace" . }}
+  name: {{ include "project-template.fullname" . }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "project-template.selectorLabels" . | nindent 6 }}
+  ingress:
+    - from:
+        - podSelector: {}

--- a/project-template/templates/networkpolicy.yaml
+++ b/project-template/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{if .Values.useNetworkpolicies }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -8,8 +9,6 @@ spec:
     matchLabels:
   {{- include "project-template.selectorLabels" . | nindent 6 }}
   ingress:
-    # Allows incoming traffic from the ingress
-    - {}
-    # Deny the traffic from other namespaces
     - from:
         - podSelector: {}
+  {{end}}


### PR DESCRIPTION
Es soll eine NetworkPolicy hinzugefügt werden. Dadurch soll die Verbindung der Pods zwischen den Namespaces unterbrochen werden. Zudem sollen folgende Cases abgedeckt sein:

**TODO:** ServiceAccount wieder einbinden beim finalen Push

NP: NetworkPolicy

- [x] NamespaceMitNP -> Internet: erlaubt
- [x] Internet -> Ingress -> NamespaceMitNP: erlaubt
- [ ] Namespace-A -> Namespace-B: verboten
- [x] NamespaceMitNP -> AndererNamespaceOhneNP: erlaubt (es wird später keine Namespaces ohne NP geben)
- [ ] NamespaceMitNP -> Ops-Namespace-MySQL (Clusterweite Datenbank)
- [x] Namespace-1 -> Ingress -> Internet -> Ingress -> Namespace-2