### PR TITLE
maxBodySize must be applied on customhosts ingress, too

### DIFF
--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -15,7 +15,10 @@ metadata:
   labels:
     {{- $labels | nindent 4 }}
   annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "20m"
+  annotations:
+{{ if .Values.maxBodySize }}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.maxBodySize | quote }}
+{{ end }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   # CNAME records must exist for all custom hostnames


### PR DESCRIPTION
The max body size annotation must also be applied if custom hosts are defined, since this creates a separate ingress