### PR TITLE
support multiple port definitions per container and service

### DIFF
--- a/project-template/README.md
+++ b/project-template/README.md
@@ -91,15 +91,15 @@ Following defaults are set already for the namespace.
 > **NOTE** - If you need to change them, you MUST talk to the DevOps team first.
 
 <dt><b>probe</b><dt>
-<dd>Defines an endpoint (and port) through which a health check is provided.
+<dd>Defines an endpoint through which a health check is provided.
  This is used by Kubernetes to check when the service is available.
- The port for the probe will be set automatically. It will be the same,
- as the value of "containerPort".
+ The port for the probe will be set automatically to 'http' if not defined.
 
  More Information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 
     probe:
         path: /
+        port: http
 
 > **OPTIONAL** - Default: no liveness/startup probe
 </dl>
@@ -157,13 +157,38 @@ For more information: https://kubernetes.io/docs/concepts/containers/images/
 
  
 <dt><b>containerPort</b><dt>
-<dd>Port which will be used for traffic by the application.
+<dd> 
+
+> **DEPRECATED**, see `ports`. 
+
+Port which will be used for traffic by the application.
+
 
     containerPort: 8080
 
 > **OPTIONAL** - Default: 8080
 
 </dl>
+
+<dt><b>ports</b><dt>
+<dd>Defines exposed and usable ports by the application. Keep in mind that only port 80 can be made public available for now, 
+others are only available within the cluster or via port forwarding.
+
+    ports:
+        http:
+            container: 8080
+            service: 80
+        mysql:
+            container: 3306
+            service: 3306
+        metrics:
+            container: 10095
+            service: 10095
+
+> **OPTIONAL** - Default: container port 8080 mapped to service port 80
+
+</dl>
+
 
 ### Volumes
 

--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -16,19 +16,18 @@ metadata:
   labels:
     {{- $labels | nindent 4 }}
   annotations:
-  annotations:
-{{ if $maxBodySize }}
+{{- if $maxBodySize }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ $maxBodySize | quote }}
-{{ end }}
+{{- end }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   # CNAME records must exist for all custom hostnames
   tls:
     - hosts:
-        {{ if .tls -}}
+        {{- if .tls }}
         - {{ .host | quote }}
       secretName: {{ .host }}
-        {{ end }}
+        {{- end }}
 
   rules:
     - host: {{ .host | quote }}

--- a/project-template/templates/deployment.yaml
+++ b/project-template/templates/deployment.yaml
@@ -29,36 +29,36 @@ spec:
         runAsGroup: 1000
         runAsUser: 1000
         fsGroup: 1000
-      {{ if .Values.gitlabImage }}
+      {{- if .Values.gitlabImage }}
       imagePullSecrets:
         - name: {{ include "project-template.image-pull-secret-name" . }}
-      {{ end }}
+      {{- end }}
       containers:
         - name: {{ .Values.name }}
-          {{ if .Values.dockerhubImage }}
+          {{- if .Values.dockerhubImage }}
           image: {{ .Values.dockerhubImage | quote }}
-          {{ else }}
+          {{- else }}
           image: {{ printf "%s:%s" .Values.gitlabImage.repository .Values.gitlabImage.tag }}
-          {{ end }}
-          {{- if .Values.probe -}}
+          {{- end }}
+          {{- if .Values.probe }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probe.path }}
-              {{ if .Values.probe.port }}
+              {{- if .Values.probe.port }}
               port: {{ .Values.probe.port }}
-              {{ else }}
+              {{- else }}
               port: {{ .Values.containerPort }}
-              {{ end }}
+              {{- end }}
             failureThreshold: 1
             periodSeconds: 10
           startupProbe:
             httpGet:
               path: {{ .Values.probe.path }}
-              {{ if .Values.probe.port }}
+              {{- if .Values.probe.port }}
               port: {{ .Values.probe.port }}
-              {{ else }}
+              {{- else }}
               port: {{ .Values.containerPort }}
-              {{ end }}
+              {{- end }}
             failureThreshold: 30
             periodSeconds: 10
           {{ end }}
@@ -69,34 +69,32 @@ spec:
           # We want to always pull the image, because we might use dev/stage/prod as image tags, not only 'latest'
           imagePullPolicy: Always
           volumeMounts:
-            {{- if .Values.persistentVolumes -}}
-            {{ range .Values.persistentVolumes }}
+            {{- if .Values.persistentVolumes }}
+            {{- range .Values.persistentVolumes }}
             - mountPath: {{ .path }}
               name: {{ .name }}-{{ $buildType }}-folder
-            {{ end }}
-            {{ end }}
-
+            {{- end }}
+            {{- end }}
             {{- if .Values.temporaryVolumes -}}
-            {{ range .Values.temporaryVolumes }}
+            {{- range .Values.temporaryVolumes }}
             - mountPath: {{ .path }}
               name: {{ .name }}-{{ $buildType }}-folder
-            {{ end }}
-            {{ end }}
-
+            {{- end }}
+            {{- end }}
           ports:
-            {{- if .Values.containerPort -}}
+            {{- if .Values.containerPort }}
             - containerPort: {{ .Values.containerPort }}
               name: http
-            {{ else }}
-            {{ range $key, $val := .Values.ports }}
+            {{- else }}
+            {{- range $key, $val := .Values.ports }}
             - containerPort: {{ $val.container }}
               name: {{ $key }}
-            {{ end }}
-            {{ end }}
+            {{- end }}
+            {{- end }}
           resources:
             {{- if .Values.resources -}}
             {{- toYaml .Values.resources | nindent 12 }}
-            {{ end }}
+            {{- end }}
           env:            
           {{- include "project-template.environment-variables-list" . | indent 12 }}
           securityContext:
@@ -113,7 +111,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .name }}-{{ $buildType }}-folder
         {{ end }}
-        {{ end }}
+        {{- end }}
 
         {{- if .Values.temporaryVolumes -}}
         {{ range .Values.temporaryVolumes }}

--- a/project-template/templates/deployment.yaml
+++ b/project-template/templates/deployment.yaml
@@ -44,13 +44,21 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.probe.path }}
+              {{ if .Values.probe.port }}
+              port: {{ .Values.probe.port }}
+              {{ else }}
               port: {{ .Values.containerPort }}
+              {{ end }}
             failureThreshold: 1
             periodSeconds: 10
           startupProbe:
             httpGet:
               path: {{ .Values.probe.path }}
+              {{ if .Values.probe.port }}
+              port: {{ .Values.probe.port }}
+              {{ else }}
               port: {{ .Values.containerPort }}
+              {{ end }}
             failureThreshold: 30
             periodSeconds: 10
           {{ end }}
@@ -76,8 +84,15 @@ spec:
             {{ end }}
 
           ports:
+            {{- if .Values.containerPort -}}
             - containerPort: {{ .Values.containerPort }}
               name: http
+            {{ else }}
+            {{ range $key, $val := .Values.ports }}
+            - containerPort: {{ $val.container }}
+              name: {{ $key }}
+            {{ end }}
+            {{ end }}
           resources:
             {{- if .Values.resources -}}
             {{- toYaml .Values.resources | nindent 12 }}

--- a/project-template/templates/ingress.yaml
+++ b/project-template/templates/ingress.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     {{- include "project-template.labels" . | nindent 4 }}
   annotations:
-{{ if .Values.maxBodySize }}
+{{- if .Values.maxBodySize }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.maxBodySize | quote }}
-{{ end }}
+{{- end }}
 spec:
   tls:
     - hosts:

--- a/project-template/templates/service.yaml
+++ b/project-template/templates/service.yaml
@@ -8,18 +8,18 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    {{- if .Values.containerPort -}}
+    {{- if .Values.containerPort }}
     - name: http
       port: 80
       targetPort: http
       protocol: TCP
-    {{ else }}
-    {{ range $key, $val := .Values.ports }}
+    {{- else }}
+    {{- range $key, $val := .Values.ports }}
     - name: {{ $key }}
       port: {{ $val.service }}
       targetPort: {{ $key }}
       protocol: TCP
-    {{ end }}
-    {{ end }}
+    {{- end }}
+    {{- end }}
   selector:
     {{- include "project-template.selectorLabels" . | nindent 8 }}

--- a/project-template/templates/service.yaml
+++ b/project-template/templates/service.yaml
@@ -8,9 +8,18 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    {{- if .Values.containerPort -}}
     - name: http
       port: 80
       targetPort: http
       protocol: TCP
+    {{ else }}
+    {{ range $key, $val := .Values.ports }}
+    - name: {{ $key }}
+      port: {{ $val.service }}
+      targetPort: {{ $key }}
+      protocol: TCP
+    {{ end }}
+    {{ end }}
   selector:
     {{- include "project-template.selectorLabels" . | nindent 8 }}

--- a/project-template/values.yaml
+++ b/project-template/values.yaml
@@ -35,6 +35,7 @@ autoscaling:
 
 #probe:
 #  path: /
+#  port: http
 
 
 ################################################################################################
@@ -54,7 +55,19 @@ autoscaling:
 #  USERNAME: "demo"
 #  PASSWORD: "demo"
 
-containerPort: 8080
+#deprecated (always mapped and provided as service port 80)
+# containerPort: 8080
+
+ports:
+  http:
+    container: 8080
+    service: 80
+#  mysql:
+#    container: 3306
+#    service: 3306
+#  metrics:
+#    container: 10095
+#    service: 10095
 
 ################################################################################################
 ### VOLUMES


### PR DESCRIPTION
Support configuration of multiple container ports mapped to multiple service ports, since this is necessary to provide at least metric endpoints within the cluster. For now it is still only possible to serve container port 80 via ingress as public (internet) port.
