### PR TITLE
Implementierung von NoFollow und NoIndex

### DIFF
--- a/project-template/README.md
+++ b/project-template/README.md
@@ -257,3 +257,14 @@ Add domains after the creation of CNAME records.
             port: 80
 
 > **OPTIONAL** - Default: no custom domain set
+
+#### noIndexingOnBuildtype:
+Every application with a host would be crawled by the search robots and then it would be
+displayed on the search results.<br>
+To disallow these crawling, you can uncomment this section inside your deployment-values.yaml
+and add the buildtype's for the stages, where the crawling should be disabled.
+
+    noIndexingOnBuildtype:
+      - dev
+      
+> **OPTIONAL** - Default: Crawling on each stage      

--- a/project-template/templates/_helpers.tpl
+++ b/project-template/templates/_helpers.tpl
@@ -80,6 +80,14 @@ rollme: {{ randAlphaNum 5 | quote }}
 {{- end -}}
 
 {{/*
+Annotations for noindex and nofollow
+*/}}
+{{- define "project-template.noindexandnofollow" -}}
+nginx.ingress.kubernetes.io/server-snippet: |-
+      add_header X-Robots-Tag "noindex, nofollow";
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "project-template.labels" -}}

--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -1,9 +1,20 @@
 {{- $fullName := include "project-template.fullname" . -}}
 {{- $namespace := include "project-template.namespace" . -}}
 {{- $labels := include "project-template.labels" . -}}
+{{- $noIndexingAndNoFollow := include "project-template.noindexandnofollow" . -}}
 {{- $buildtype := .Values.buildtype -}}
 {{- $maxBodySize := .Values.maxBodySize -}}
 {{- $hasCustomDomains := contains ("TRUE") (include "project-template.filteredcustomdomains" .) -}}
+
+{{- $noIndexingAnnotation := false -}}
+{{- if .Values.noIndexingOnBuildtype -}}
+{{ range $val := .Values.noIndexingOnBuildtype }}
+{{- if eq $val $buildtype -}}
+{{- $noIndexingAnnotation = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- if and (.Values.customhosts) (.Values.servePublicly) ($hasCustomDomains) -}}
 {{range .Values.customhosts }}
 {{- if eq .buildtype $buildtype -}}
@@ -16,6 +27,9 @@ metadata:
   labels:
     {{- $labels | nindent 4 }}
   annotations:
+  {{- if $noIndexingAnnotation -}}
+    {{- $noIndexingAndNoFollow | nindent 4 -}}
+  {{- end -}}
 {{- if $maxBodySize }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ $maxBodySize | quote }}
 {{- end }}

--- a/project-template/templates/ingress.yaml
+++ b/project-template/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.servePublicly -}}
+  {{- $buildtype := .Values.buildtype -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -7,6 +8,13 @@ metadata:
   labels:
     {{- include "project-template.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.noIndexingOnBuildtype -}}
+    {{range $val := .Values.noIndexingOnBuildtype}}
+    {{- if eq $val $buildtype -}}
+      {{- include "project-template.noindexandnofollow" . | nindent 4 -}}
+    {{- end -}}
+    {{- end -}}
+    {{- end -}}
 {{- if .Values.maxBodySize }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.maxBodySize | quote }}
 {{- end }}

--- a/project-template/values.yaml
+++ b/project-template/values.yaml
@@ -100,3 +100,6 @@ servePublicly: true
 #    paths:
 #      - path: "/"
 #        port: 80
+
+#noIndexingOnBuildtype:
+#  - dev


### PR DESCRIPTION
Es gibt nun die Möglichkeit, in seiner deployment-values.yaml stages anzugeben, die mit dem Tag `noindex` und `nofollow` versehen werden sollen.
Getestet werden kann dies unter folgender Domain: https://test-malte-malte-test.delta.k8s-wdy.de/
Zudem kann im Screenshot gesehen werden, dass im Response-Header die x-robots-tag's gesetzt werden.
![Bildschirmfoto 2020-11-24 um 11 49 05](https://user-images.githubusercontent.com/67408175/100084485-1da96e00-2e4b-11eb-9ea1-b4c245256c0d.png)
