### PR TITLE
OPS-228 cpu limit

### DIFF
--- a/user-creation/templates/user-manifests.yaml
+++ b/user-creation/templates/user-manifests.yaml
@@ -57,7 +57,9 @@ spec:
   hard:
     # request can never be greater than the limit
     # => a malicous user can not set the request to e.g. 15GB while conforming to a set limit of 2GB
+{{- if .cpuLimit }}
     limits.cpu: {{ .cpuLimit }}
+{{- end }}
     limits.memory: {{ .ramLimit }}
 
 ---

--- a/user-creation/templates/user-manifests.yaml
+++ b/user-creation/templates/user-manifests.yaml
@@ -1,4 +1,8 @@
 
+{{- if empty .Values.projects }}
+{{- fail "No projects found - add projects to get a valid yaml file!" -}}
+{{- end -}}
+
 {{- $labels := include "user-creation.labels" . | nindent 4 }}
 {{- range .Values.projects }}
 {{ $namespace := .name | replace "/" "-"}}

--- a/user-creation/templates/user-manifests.yaml
+++ b/user-creation/templates/user-manifests.yaml
@@ -36,7 +36,7 @@ spec:
   # default limits per Pod
   # using 1:4 ratio as default
   - default:
-      cpu: 125m
+  #    cpu: 125m
       memory: 512Mi
     defaultRequest:
       cpu: 10m


### PR DESCRIPTION
CPU limit should be optional, CPU should be fully distributed among services. Services that should be restricted can do so by themself. With global limits, CPU would be throttled, even if free.