### PR TITLE
Add option to set nginx proxy buffer size

### DIFF
--- a/project-template/README.md
+++ b/project-template/README.md
@@ -122,6 +122,17 @@ or `32m` (32MB). More information can befound in the [nginx readme](https://gith
 
 > **OPTIONAL** - Default: not set
 
+#### proxyBuffer
+
+Set the size of the proxy buffer for reading the first part of the proxied response from a pod. Units are denoted with k, m and g for kilobytes, megabytes and gigabytes, respectively.
+Typically values do not exceed kilobytes.
+More information can befound in the [nginx readme](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#proxy-buffer-size).
+
+    proxyBuffer: "16k"
+
+> **OPTIONAL** - Default: 4 kilobytes
+
+
 ### Docker image
 
 The following configurations are only necessary, if you do not use the default CI deployment process.

--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -4,6 +4,7 @@
 {{- $noIndexingAndNoFollow := include "project-template.noindexandnofollow" . -}}
 {{- $buildtype := .Values.buildtype -}}
 {{- $maxBodySize := .Values.maxBodySize -}}
+{{- $proxyBuffer := .Values.proxyBuffer -}}
 {{- $hasCustomDomains := contains ("TRUE") (include "project-template.filteredcustomdomains" .) -}}
 
 {{- $noIndexingAnnotation := false -}}
@@ -32,6 +33,9 @@ metadata:
   {{- end -}}
 {{- if $maxBodySize }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ $maxBodySize | quote }}
+{{- end }}
+{{- if $proxyBuffer }}
+    nginx.ingress.kubernetes.io/proxy-buffer-size: {{ $proxyBuffer | quote }}
 {{- end }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:

--- a/project-template/templates/ingress.yaml
+++ b/project-template/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
 {{- if .Values.maxBodySize }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.maxBodySize | quote }}
 {{- end }}
+{{- if .Values.proxyBuffer }}
+    nginx.ingress.kubernetes.io/proxy-buffer-size: {{ .Values.proxyBuffer | quote }}
+{{- end }}
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Some services (namely keycloak) have trouble with the default
nginx proxy-buffer size of 4k. This PR adds a config option to set a custom
proxy buffer size for an ingress

ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#proxy-buffer-size

This was tested by running helm template with a deployment-values.yaml
file of a keycloak deployment of ours