### PR TITLE
Update to kubernetes 23

### DIFF
--- a/project-template/templates/cronjob.yaml
+++ b/project-template/templates/cronjob.yaml
@@ -10,7 +10,7 @@
 
 {{- if and (.Values.mysqlBackup) ($shouldCreateCronJob) -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   namespace: {{ include "project-template.namespace" . }}

--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -20,7 +20,7 @@
 {{range .Values.customhosts }}
 {{- if eq .buildtype $buildtype -}}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: {{ $namespace }}

--- a/project-template/templates/horizontal-pod-autoscaler.yaml
+++ b/project-template/templates/horizontal-pod-autoscaler.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   namespace: {{ include "project-template.namespace" . }}

--- a/project-template/templates/ingress.yaml
+++ b/project-template/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.servePublicly -}}
   {{- $buildtype := .Values.buildtype -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: {{ include "project-template.namespace" . }}

--- a/project-template/templates/pod-disruption-budget.yaml
+++ b/project-template/templates/pod-disruption-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   namespace: {{ include "project-template.namespace" . }}

--- a/user-creation/templates/user-manifests.yaml
+++ b/user-creation/templates/user-manifests.yaml
@@ -75,7 +75,7 @@ metadata:
 ---
 # Bind the role to the created ServiceAccount
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $username }}-RoleBinding
   namespace: {{ $namespace }}


### PR DESCRIPTION
This PR includes everything needed to use our helm charts on kubernetes 23.

TODO:

- [x] read all changelogs and handle any api changes
- [ ] check cert-manager
- [ ] check velero
- [ ] Check if we can use the CSI Volume Snapshot feature instead of restic? It went GA with 1.20
- [x] check prometheus and `kube-state-metrics`
- [ ] check network policies