### PR TITLE
Update Ingress Resource for k8s 21

### DIFF
--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -52,9 +52,12 @@ spec:
       http:
         paths: {{ range .paths }}
           - path: {{ .path }}
+            pathType: "ImplementationSpecific"
             backend:
-              servicePort: {{ .port }}
-              serviceName: {{ $fullName }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .port }}
           {{ end }}
 {{ end }}
 {{ end }}

--- a/project-template/templates/ingress.yaml
+++ b/project-template/templates/ingress.yaml
@@ -30,7 +30,10 @@ spec:
       http:
         paths:
           - path: "/"
+            pathType: "ImplementationSpecific"
             backend:
-              servicePort: 80
-              serviceName: {{ include "project-template.fullname" . }}
+              service:
+                name: {{ include "project-template.fullname" . }}
+                port:
+                  number: 80
 {{ end }}


### PR DESCRIPTION
This commit implements the changes introduces in [1] and  documented in
[2]

Mainly, this concerns the definiton of a `backend` and the necessity to
declare a `pathType`[3].

I choose `ImplementationSpecific` here, as this was the default
previously and passes the decision how the path should be matched to our
`nignx-ingress`.

[1] https://github.com/kubernetes/kubernetes/pull/89778
[2] https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
[3] https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types