### PR TITLE
ingress,custom-ingress: add nginx ingress class

### DIFF
--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -39,6 +39,7 @@ metadata:
 {{- end }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
+  ingressClassName: nginx
   # CNAME records must exist for all custom hostnames
   tls:
     - hosts:

--- a/project-template/templates/ingress.yaml
+++ b/project-template/templates/ingress.yaml
@@ -22,6 +22,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: {{ .Values.proxyBuffer | quote }}
 {{- end }}
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - {{ include "project-template.domain" . }}


### PR DESCRIPTION
Due to an update of nginx-ingress, we need to add the "nignx" ingressClass to all our ingress'es