### PR TITLE
Add support for generic cronjob deployments

### DIFF
--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -39,6 +39,7 @@ metadata:
 {{- end }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
+  ingressClassName: nginx
   # CNAME records must exist for all custom hostnames
   tls:
     - hosts:

--- a/project-template/templates/ingress.yaml
+++ b/project-template/templates/ingress.yaml
@@ -22,6 +22,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: {{ .Values.proxyBuffer | quote }}
 {{- end }}
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - {{ include "project-template.domain" . }}


### PR DESCRIPTION
# What this is

In the past, this Chart posed a feature to create a cronjob for mysql backups. For a few years now, no one used this.

Instead, the need for deploying generics Cronjobs arised from the team. This PR gets rid of the old definition and instead implements a generic way to deploy a CronJob instead of a Deployment

# Details

TBD

# How to test

```bash
# Start a minikube cluster locally
minikube start

# Create a test namespace
kubectl create ns bar

# Source the docker env from minikube
eval $(minikube docker-env)

# Create a Dockerfile for a test cronjob container
cat <<EOF > Dockerfile
FROM ubuntu:latest

RUN apt update -yy
RUN apt install -yy curl

ENTRYPOINT  curl nginx?hello=from_cronjob
EOF

# Build the dockerfile (this will make it usable by minikube
docker build -t tester .

# Create a manifest for a nignx deployment (for logging requests from the cronjob)
cat << EOF > nginx.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  namespace: bar
spec:
  selector:
    matchLabels:
      app: nginx
  replicas: 1
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
  namespace: bar
spec:
  selector:
    app: nginx
  ports:
    - protocol: TCP
      port: 80
      targetPort: 80
EOF

# Deploy the nginx pod
kubectl apply -f nginx.yaml

# Create the helm values to use
cat << EOF > values-test-cronjob.yaml
cronjob:
  schedule: "* * * * *"


name: "foo"
namespace: "bar"


gitlabImage:
   repository: "tester"
   tag: "latest"


buildtype: "prod"

contact:
    name: "Alice Henderson"

replicas: 1

autoscaling:
  enabled: false

ports:
  http:
    container: 8080
    service: 80

temporaryVolumes:
  - path: "/var/cache/nginx"
    name: "var-cache-nginx"
  - path: "/tmp"
    name: "tmp"

servePublicly: true

# Default "buildtype > PriorityClassName mapping
# The values can be overwritten individually.
priorityClasses:
  dev: wdy-develop
  stage: wdy-staging
  prod: wdy-production
EOF

# Deploy the cronjob via the helm chart
# The DEBUG_imagePullPolicy is a hack to trick minikube into taking the image from docker instead of trying to pull it
# This option is not intended to be used by the team and hence not documented
helm upgrade --install -f values-test-cronjob.yaml --namespace bar --set DEBUG_imagePullPolicy=Never  foo project-template

# Observe that every minute a request to the nginx pod is made from the cronjob
kubectl logs -f -l 'app=nginx' -n bar

```
