### PR TITLE
cronjob: fix generated yaml

### DIFF
--- a/project-template/templates/cronjob.yaml
+++ b/project-template/templates/cronjob.yaml
@@ -9,12 +9,12 @@ metadata:
   name: {{ .Values.name }}
 spec:
   schedule: "{{- .Values.cronjob.schedule -}}"
-  concurrencyPolicy: {{- .Values.cronjob.concurrencyPolicy | default "Forbid"  -}}
-  successfulJobsHistoryLimit: {{- .Values.cronjob.successfulJobsHistoryLimit | default "5"  -}}
-  failedJobsHistoryLimit: {{- .Values.cronjob.failedJobsHistoryLimit | default "5"  -}}
-  {{- if .Values.cronjob.startingDeadlineSeconds  -}}
-  startingDeadlineSeconds: {{- .Values.cronjob.startingDeadlineSeconds  -}}
-  {{- end  -}}
+  concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy | default "Forbid"  }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit | default "5"  }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit | default "5"  }}
+  {{- if .Values.cronjob.startingDeadlineSeconds  }}
+  startingDeadlineSeconds: {{ .Values.cronjob.startingDeadlineSeconds  }}
+  {{- end  }}
   suspend: {{ .Values.cronjob.suspend | default false  }}
   jobTemplate:
     spec:


### PR DESCRIPTION
Before this, the generated yaml for cronjobs was highly borked: 

```yaml
 schedule: "0 4 * * *"
 concurrencyPolicy:ForbidsuccessfulJobsHistoryLimit:5failedJobsHistoryLimit:5startingDeadlineSeconds:10suspend: false
```

Now it is:

```yaml
  schedule: "0 4 * * *"
  concurrencyPolicy: Forbid
  successfulJobsHistoryLimit: 5
  failedJobsHistoryLimit: 5
  startingDeadlineSeconds: 10
  suspend: false
```