### PR TITLE
OPS-834 disable robots.txt configuration

### DIFF
--- a/project-template/templates/custom-ingress.yaml
+++ b/project-template/templates/custom-ingress.yaml
@@ -28,9 +28,6 @@ metadata:
   labels:
     {{- $labels | nindent 4 }}
   annotations:
-  {{- if $noIndexingAnnotation -}}
-    {{- $noIndexingAndNoFollow | nindent 4 -}}
-  {{- end -}}
 {{- if $maxBodySize }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ $maxBodySize | quote }}
 {{- end }}

--- a/project-template/templates/ingress.yaml
+++ b/project-template/templates/ingress.yaml
@@ -9,13 +9,6 @@ metadata:
   labels:
     {{- include "project-template.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.noIndexingOnBuildtype -}}
-    {{range $val := .Values.noIndexingOnBuildtype}}
-    {{- if eq $val $buildtype -}}
-      {{- include "project-template.noindexandnofollow" . | nindent 4 -}}
-    {{- end -}}
-    {{- end -}}
-    {{- end -}}
 {{- if .Values.maxBodySize }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.maxBodySize | quote }}
 {{- end }}


### PR DESCRIPTION
Disables the configuration for robots.txt since it is no longer supported by nginx controller